### PR TITLE
Add "code" to dropdown item label.

### DIFF
--- a/src/app/components/FormInputs/Dropdown/Dropdown.tsx
+++ b/src/app/components/FormInputs/Dropdown/Dropdown.tsx
@@ -1,13 +1,10 @@
-import { useContext } from 'react';
 import { Controller, Control } from 'react-hook-form';
 import {
   Select as MuiSelect,
   MenuItem,
   FormControl,
-  FormLabel,
   InputLabel,
   FormHelperText,
-  SelectChangeEvent,
 } from '@mui/material';
 
 import { DropdownItemType } from '@app/utils/zod.util';

--- a/src/app/components/FormInputs/Dropdown/Dropdown.tsx
+++ b/src/app/components/FormInputs/Dropdown/Dropdown.tsx
@@ -49,7 +49,7 @@ export const Dropdown = ({
           ) : null}
           {options.map(({ value, code, label }) => (
             <MenuItem key={value} value={code}>
-              {label}
+              {`${code} - ${label}`}
             </MenuItem>
           ))}
         </MuiSelect>


### PR DESCRIPTION
Una pequeña PR donde corrijo un requerimiento donde se pide que el label que conforma un item de un dropdown sea de la forma: `"[code] - [label]"`.